### PR TITLE
Handle gameserver status changes

### DIFF
--- a/lib/Nitrapi/Common/Exceptions/NitrapiServiceNotActiveException.php
+++ b/lib/Nitrapi/Common/Exceptions/NitrapiServiceNotActiveException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace Nitrapi\Common\Exceptions;
+
+class NitrapiServiceNotActiveException extends NitrapiException {
+}


### PR DESCRIPTION
If a gameserver service switches from active to another state (suspended,
admin locked, ...), we cannot refresh the gameserver details, because
the service is gone. We throw a exception in this case, so the GUI can
handle that case. Further we use the old data, if the refresh of the
gameserver details does not result in a proper result, to prevent small
network problems.