### PR TITLE
String representation for services.

### DIFF
--- a/lib/Nitrapi/Services/Service.php
+++ b/lib/Nitrapi/Services/Service.php
@@ -42,6 +42,15 @@ abstract class Service extends NitrapiObject
         $this->loadData($data);
     }
 
+     /**
+     * Return the name of the service as a string.
+     *
+     * @return string Name of the service
+     */
+    public function __toString() {
+        return strtolower(substr(get_class($this), (int)strrpos(get_class($this), '\\') + 1));
+    }
+
     /**
      * Returns the current location id
      *


### PR DESCRIPTION
Cast a service to a string, and you get a string representation of that
service. This is useful if you want to work with the service type outside
of the PHP codebase like storing it in a database, add it as a metadata,
to an error report or generate other output like a JSON export.